### PR TITLE
fix chat subscription

### DIFF
--- a/plugins/chat/index.tsx
+++ b/plugins/chat/index.tsx
@@ -68,7 +68,7 @@ const Root = () => {
       <style>{`
         .OPChat {
           position: absolute;
-          bottom: 122px;
+          bottom: 132px;
           left: 50px;
           right: 50px;
           display: flex;

--- a/plugins/chat/index.tsx
+++ b/plugins/chat/index.tsx
@@ -71,6 +71,7 @@ const Root = () => {
           bottom: 132px;
           left: 50px;
           right: 50px;
+          z-index: 100;
           display: flex;
           flex-direction: column;
           gap: 5px;

--- a/plugins/chat/useChatMessages.tsx
+++ b/plugins/chat/useChatMessages.tsx
@@ -61,7 +61,7 @@ export const useChatMessages = () => {
       subscription.unsubscribe();
       relay.unsubscribe(chatRelayLabel);
     };
-  });
+  }, []);
 
   const postMessage = useCallback(
     async (input: string) => {


### PR DESCRIPTION
I didn't give the useEffect hook a dependency array, so it was re-subscribing every render. And it looks like `relay.subscribe(label)` fires off a request so it could be that we were re-rendering+re-subscribing during chat messages and dropping them.

This change should make it so that this useEffect now only registers once for the duration of the plugin.

Also fixed some visual issues where chat was hard to read due to other UI elements being in the way.